### PR TITLE
Fix syntax highlighting for HTML tags with dashes

### DIFF
--- a/syntaxes/DustBuster.tmLanguage
+++ b/syntaxes/DustBuster.tmLanguage
@@ -242,7 +242,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(&lt;)([a-zA-Z0-9:-]+)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
+					<string>(&lt;)([a-zA-Z0-9\-:]++)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
As per the W3C Web Components spec, custom elements must contain dashes in their tag names:

http://w3c.github.io/webcomponents/spec/custom/#dfn-custom-element-type

> (...) must contain a U+002D HYPHEN-MINUS character
